### PR TITLE
Home for contract texts

### DIFF
--- a/model/analysis/extraction.smithy
+++ b/model/analysis/extraction.smithy
@@ -5,7 +5,6 @@ namespace equaliq.extraction
 
 use equaliq#StringList
 use equaliq#ContractType
-use equaliq#TaggedText
 
 // General Contract Extraction not directly tied to EQ or IQ analysis
 
@@ -18,8 +17,6 @@ structure ContractExtractionResult {
   terms: ExtractionTermMap
 
   variables: ContractVariableMap
-
-  contractText: ContractMarkupResult
 }
 
 map ExtractionTermMap {
@@ -131,15 +128,6 @@ structure ContractVariable {
 
   // where the term is defined (e.g., "Section 7(ii)(c)(I)") - for EQ_TERM and DISCOVERED_TERM only
   definitionCitation: String
-}
-
-
-structure ContractMarkupResult {
-  @required
-  markedUpContract: TaggedText
-
-  @required
-  statistics: MarkupStatistics
 }
 
 structure MarkupStatistics {

--- a/model/contracts.smithy
+++ b/model/contracts.smithy
@@ -7,7 +7,8 @@ use equaliq.iq#IqModeData
 use equaliq.extraction#ContractExtractionResult
 use equaliq.extraction#ExtractionTermMap
 use equaliq.extraction#ContractVariableMap
-use equaliq.extraction#ContractMarkupResult
+use equaliq#TaggedText
+use equaliq#PlainText
 
 // Contract structures
 
@@ -444,6 +445,10 @@ structure TTSItem {
 
 }
 
+structure ContractTexts {
+  originalText: PlainText
+  taggedText: TaggedText
+}
 
 structure ContractAnalysisRecord {
   @required
@@ -471,7 +476,7 @@ structure ContractAnalysisRecord {
 
   variables: ContractVariableMap
 
-  contractText: ContractMarkupResult
+  contractTexts: ContractTexts
 
   sharedUsers: SharedUserDetailsList
   hasTTS: Boolean

--- a/model/util.smithy
+++ b/model/util.smithy
@@ -36,3 +36,8 @@ structure TaggedText {
   @required
   text: String
 }
+
+structure PlainText {
+  @required
+  text: String
+}

--- a/python/api_model/types/models.py
+++ b/python/api_model/types/models.py
@@ -187,16 +187,12 @@ class IqModeSectionKey(Enum):
     liabilitySafeguards = 'liabilitySafeguards'
 
 
-class MarkupStatistics(BaseModel):
-    originalLength: float
-    markedUpLength: float
-    totalVariables: float
-    processingTimeSeconds: float
-    chunksProcessed: float
-
-
 class PingResponseContent(BaseModel):
     message: str
+
+
+class PlainText(BaseModel):
+    text: str
 
 
 class PresignedPostData(BaseModel):
@@ -308,11 +304,6 @@ class ValidationErrorResponseContent(BaseModel):
     message: str
 
 
-class ContractMarkupResult(BaseModel):
-    markedUpContract: TaggedText
-    statistics: MarkupStatistics
-
-
 class ContractMetadata(BaseModel):
     contractId: str = Field(..., pattern='^[A-Za-z0-9-]+$')
     name: str
@@ -340,6 +331,11 @@ class ContractSummaryItem(BaseModel):
     sharedWith: list[SharedWithItem] | None
     sharedUsers: list[SharedUser] | None
     sharedEmails: list[SharedEmail] | None
+
+
+class ContractTexts(BaseModel):
+    originalText: PlainText | None
+    taggedText: TaggedText | None
 
 
 class ContractVariable(BaseModel):
@@ -455,7 +451,6 @@ class ContractExtractionResult(BaseModel):
     parties: list[str] | None
     terms: ExtractionTermMap | None
     variables: ContractVariableMap | None
-    contractText: ContractMarkupResult | None
 
 
 class OWNERSHIP(BaseModel):
@@ -532,7 +527,7 @@ class ContractAnalysisRecord(BaseModel):
     parties: list[str] | None
     terms: ExtractionTermMap | None
     variables: ContractVariableMap | None
-    contractText: ContractMarkupResult | None
+    contractTexts: ContractTexts | None
     sharedUsers: list[SharedUserDetails] | None
     hasTTS: bool | None
     isSpecial: bool | None

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -86,7 +86,7 @@ export type ContractAnalysisRecord = {
   parties?: string[];
   terms?: ExtractionTermMap;
   variables?: ContractVariableMap;
-  contractText?: ContractMarkupResult;
+  contractTexts?: ContractTexts;
   sharedUsers?: SharedUserDetails[];
   hasTTS?: boolean;
   isSpecial?: boolean;
@@ -97,12 +97,6 @@ export type ContractExtractionResult = {
   parties?: string[];
   terms?: ExtractionTermMap;
   variables?: ContractVariableMap;
-  contractText?: ContractMarkupResult;
-};
-
-export type ContractMarkupResult = {
-  markedUpContract: TaggedText;
-  statistics: MarkupStatistics;
 };
 
 export type ContractMetadata = {
@@ -129,6 +123,11 @@ export type ContractSummaryItem = {
   sharedWith?: string[];
   sharedUsers?: string[];
   sharedEmails?: string[];
+};
+
+export type ContractTexts = {
+  originalText?: PlainText;
+  taggedText?: TaggedText;
 };
 
 export type ContractVariable = {
@@ -354,16 +353,12 @@ export type ListSpecialContractsResponseContent = {
   shared: ContractSummaryItem[];
 };
 
-export type MarkupStatistics = {
-  originalLength: number;
-  markedUpLength: number;
-  totalVariables: number;
-  processingTimeSeconds: number;
-  chunksProcessed: number;
-};
-
 export type PingResponseContent = {
   message: string;
+};
+
+export type PlainText = {
+  text: string;
 };
 
 export type PresignedPostData = {
@@ -442,7 +437,7 @@ export type UploadProfilePictureRequestContent = {
 
 export type UploadProfilePictureResponseContent = {
   message?: string;
-  picture_id?: string;
+  pictureId?: string;
 };
 
 export type UserProfile = {

--- a/typescript/src/models.ts
+++ b/typescript/src/models.ts
@@ -266,7 +266,7 @@ export interface components {
             parties?: string[];
             terms?: components["schemas"]["ExtractionTermMap"];
             variables?: components["schemas"]["ContractVariableMap"];
-            contractText?: components["schemas"]["ContractMarkupResult"];
+            contractTexts?: components["schemas"]["ContractTexts"];
             sharedUsers?: components["schemas"]["SharedUserDetails"][];
             hasTTS?: boolean;
             isSpecial?: boolean;
@@ -276,11 +276,6 @@ export interface components {
             parties?: string[];
             terms?: components["schemas"]["ExtractionTermMap"];
             variables?: components["schemas"]["ContractVariableMap"];
-            contractText?: components["schemas"]["ContractMarkupResult"];
-        };
-        ContractMarkupResult: {
-            markedUpContract: components["schemas"]["TaggedText"];
-            statistics: components["schemas"]["MarkupStatistics"];
         };
         ContractMetadata: {
             contractId: string;
@@ -308,6 +303,10 @@ export interface components {
             sharedWith?: string[];
             sharedUsers?: string[];
             sharedEmails?: string[];
+        };
+        ContractTexts: {
+            originalText?: components["schemas"]["PlainText"];
+            taggedText?: components["schemas"]["TaggedText"];
         };
         /** @enum {string} */
         ContractType: ContractType;
@@ -523,16 +522,11 @@ export interface components {
             owned: components["schemas"]["ContractSummaryItem"][];
             shared: components["schemas"]["ContractSummaryItem"][];
         };
-        MarkupStatistics: {
-            originalLength: number;
-            markedUpLength: number;
-            totalVariables: number;
-            /** Format: float */
-            processingTimeSeconds: number;
-            chunksProcessed: number;
-        };
         PingResponseContent: {
             message: string;
+        };
+        PlainText: {
+            text: string;
         };
         PresignedPostData: {
             url: string;


### PR DESCRIPTION
- New ContractTexts field to house the different phases in the contract. text lifetime. 
- Added PlainText type alongside TaggedText.
**Open to better names than ContractTexts**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new structure for contract text data, allowing access to both original and tagged versions of contract text.

* **Improvements**
  * Simplified contract analysis records by replacing the previous markup result structure with a more straightforward format.
  * Updated naming conventions for improved consistency in response properties.

* **Removals**
  * Removed previous contract markup result and statistics fields from contract-related data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->