### PR TITLE
Fixing uploadProfilePicture to use presignedURLs

### DIFF
--- a/model/equaliq.smithy
+++ b/model/equaliq.smithy
@@ -36,7 +36,6 @@ service EqualIQ {
 // When changing APIs, we sometimes want to expose unified types that aren't directly tied to any API.
 structure ExposedTypes { 
   contractAnalysisRecord: ContractAnalysisRecord
-  uploadProfilePictureInput: UploadProfilePictureInput
 }
 
 // This API is used simply to expose types

--- a/model/profiles.smithy
+++ b/model/profiles.smithy
@@ -76,7 +76,6 @@ operation UploadProfilePicture {
 }
 
 structure UploadProfilePictureInput {
-    
 }
 
 structure UploadProfilePictureOutput {

--- a/python/api_model/types/models.py
+++ b/python/api_model/types/models.py
@@ -280,10 +280,6 @@ class UpdateProfileResponseContent(BaseModel):
     updatedFields: list[str] | None
 
 
-class UploadProfilePictureInput(BaseModel):
-    pass
-
-
 class UploadProfilePictureResponseContent(BaseModel):
     url_info: PresignedPostData
 
@@ -534,7 +530,6 @@ class ContractAnalysisRecord(BaseModel):
 
 class ExposeTypesResponseContent(BaseModel):
     contractAnalysisRecord: ContractAnalysisRecord | None
-    uploadProfilePictureInput: UploadProfilePictureInput | None
 
 
 class GetContractResponseContent(BaseModel):

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -222,7 +222,6 @@ export type EqResponsibilitiesCard = {
 
 export type ExposeTypesResponseContent = {
   contractAnalysisRecord?: ContractAnalysisRecord;
-  uploadProfilePictureInput?: UploadProfilePictureInput;
 };
 
 export type ExtractionTerm = {
@@ -431,8 +430,6 @@ export type UpdateProfileResponseContent = {
   userId: string;
   updatedFields?: string[];
 };
-
-export type UploadProfilePictureInput = unknown;
 
 export type UploadProfilePictureResponseContent = {
   url_info: PresignedPostData;

--- a/typescript/src/models.ts
+++ b/typescript/src/models.ts
@@ -405,7 +405,6 @@ export interface components {
         };
         ExposeTypesResponseContent: {
             contractAnalysisRecord?: components["schemas"]["ContractAnalysisRecord"];
-            uploadProfilePictureInput?: components["schemas"]["UploadProfilePictureInput"];
         };
         ExtractionTerm: {
             name: string;
@@ -588,7 +587,6 @@ export interface components {
             userId: string;
             updatedFields?: string[];
         };
-        UploadProfilePictureInput: Record<string, never>;
         UploadProfilePictureResponseContent: {
             url_info: components["schemas"]["PresignedPostData"];
         };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated profile picture upload flow to use pre-signed upload data. The request no longer accepts image or user ID fields. The response now returns url_info with upload instructions.
* **New Features**
  * Enables direct upload of profile pictures using provided pre-signed form data.
* **Documentation**
  * Clarified the new upload response format and request expectations.
* **Chores**
  * Removed deprecated request/response fields related to image, user ID, message, and picture ID.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->