### PR TITLE
New flag type for EqModeCard

### DIFF
--- a/model/analysis/eq.smithy
+++ b/model/analysis/eq.smithy
@@ -131,7 +131,16 @@ enum FlagSeverity {
 
 structure EqModeCardFlag {
   @required
+  reasoning: String
+
+  @required
+  referenceKey: String
+
+  @required
   severity: FlagSeverity
+
+  @required
+  summary: String
 
   @required
   context: String

--- a/model/analysis/eq.smithy
+++ b/model/analysis/eq.smithy
@@ -118,6 +118,30 @@ structure EqModeCard {
   audioSrc: String
 
   ttsSrcUrl: Url
+
+  flags: EqModeCardFlagList
+}
+
+enum FlagSeverity {
+  RED = "red"
+  YELLOW = "yellow"
+  ORANGE = "orange"
+  BLUE = "blue"
+}
+
+structure EqModeCardFlag {
+  @required
+  severity: FlagSeverity
+
+  @required
+  context: String
+
+  @required
+  referenceKey: String
+}
+
+list EqModeCardFlagList {
+  member: EqModeCardFlag
 }
 
 @documentation("Deprecated")

--- a/model/analysis/eq.smithy
+++ b/model/analysis/eq.smithy
@@ -119,14 +119,14 @@ structure EqModeCard {
 
   ttsSrcUrl: Url
 
-  flags: EqModeCardFlagList
+  flags: EqModeCardFlagMap
 }
 
 enum FlagSeverity {
-  RED = "red"
-  YELLOW = "yellow"
-  ORANGE = "orange"
-  BLUE = "blue"
+  CRITICAL = "critical"
+  WARN = "warn"
+  INFO = "info"
+  POSITIVE = "positive"
 }
 
 structure EqModeCardFlag {
@@ -135,13 +135,11 @@ structure EqModeCardFlag {
 
   @required
   context: String
-
-  @required
-  referenceKey: String
 }
 
-list EqModeCardFlagList {
-  member: EqModeCardFlag
+map EqModeCardFlagMap {
+  key: String
+  value: EqModeCardFlag
 }
 
 @documentation("Deprecated")

--- a/python/api_model/types/models.py
+++ b/python/api_model/types/models.py
@@ -180,6 +180,13 @@ class FixedValueTermInference(BaseModel):
     subterms: list[FixedTermValue] | None
 
 
+class FlagSeverity(Enum):
+    red = 'red'
+    yellow = 'yellow'
+    orange = 'orange'
+    blue = 'blue'
+
+
 class GetContractReadURLRequestContent(BaseModel):
     contractId: str = Field(..., pattern='^[A-Za-z0-9-]+$')
 
@@ -552,8 +559,8 @@ class ContractVariable(BaseModel):
     definitionCitation: str | None
 
 
-class ContractVariableMap(RootModel[dict[str, ContractVariable] | None]):
-    root: dict[str, ContractVariable] | None
+class ContractVariableMap(RootModel[dict[str, ContractVariable]]):
+    root: dict[str, ContractVariable]
 
 
 class CreateOrgCustomRoleRequestContent(BaseModel):
@@ -598,6 +605,12 @@ class EqDurationCard(BaseModel):
     durationDetails: list[SimpleTermDescription] | None
 
 
+class EqModeCardFlag(BaseModel):
+    severity: FlagSeverity
+    context: str
+    referenceKey: str
+
+
 class EqOwnershipCard(BaseModel):
     ownershipTerms: list[SimpleTermDescription]
 
@@ -618,8 +631,8 @@ class ExtractionTerm(BaseModel):
     originalValue: str | None
 
 
-class ExtractionTermMap(RootModel[dict[str, ExtractionTerm] | None]):
-    root: dict[str, ExtractionTerm] | None
+class ExtractionTermMap(RootModel[dict[str, ExtractionTerm]]):
+    root: dict[str, ExtractionTerm]
 
 
 class GetOrgThemeResponseContent(BaseModel):
@@ -650,8 +663,8 @@ class IqModeSection(BaseModel):
     questions: list[IqModeQuestion]
 
 
-class IqModeSectionMap(RootModel[dict[str, IqModeSection] | None]):
-    root: dict[str, IqModeSection] | None
+class IqModeSectionMap(RootModel[dict[str, IqModeSection]]):
+    root: dict[str, IqModeSection]
 
 
 class ListContractsResponseContent(BaseModel):
@@ -711,8 +724,8 @@ class OrgCustomRole(BaseModel):
     memberCount: float | None
 
 
-class OrgCustomRoleMap(RootModel[dict[str, OrgCustomRole] | None]):
-    root: dict[str, OrgCustomRole] | None
+class OrgCustomRoleMap(RootModel[dict[str, OrgCustomRole]]):
+    root: dict[str, OrgCustomRole]
 
 
 class OrgInvite(BaseModel):
@@ -736,8 +749,8 @@ class OrgInvite(BaseModel):
     )
 
 
-class OrgInviteMap(RootModel[dict[str, OrgInvite] | None]):
-    root: dict[str, OrgInvite] | None
+class OrgInviteMap(RootModel[dict[str, OrgInvite]]):
+    root: dict[str, OrgInvite]
 
 
 class OrgMember(BaseModel):
@@ -754,8 +767,8 @@ class OrgMember(BaseModel):
     userProfile: UserProfile | None
 
 
-class OrgMemberMap(RootModel[dict[str, OrgMember] | None]):
-    root: dict[str, OrgMember] | None
+class OrgMemberMap(RootModel[dict[str, OrgMember]]):
+    root: dict[str, OrgMember]
 
 
 class ResendOrgInviteResponseContent(BaseModel):
@@ -858,10 +871,11 @@ class EqModeCard(BaseModel):
         None,
         pattern='^(https?:\\/\\/)?(www\\.)?[-a-zA-Z0-9@%._\\+~#=]{2,256}\\.[a-z]{2,6}\\b([-a-zA-Z0-9@:%_\\+.~#?&/=]*)$',
     )
+    flags: list[EqModeCardFlag] | None
 
 
-class EqModeCardMap(RootModel[dict[str, EqModeCard] | None]):
-    root: dict[str, EqModeCard] | None
+class EqModeCardMap(RootModel[dict[str, EqModeCard]]):
+    root: dict[str, EqModeCard]
 
 
 class EqModeData(BaseModel):
@@ -876,8 +890,8 @@ class IqModePerspective(BaseModel):
     sections: IqModeSectionMap
 
 
-class IqModePerspectiveMap(RootModel[dict[str, IqModePerspective] | None]):
-    root: dict[str, IqModePerspective] | None
+class IqModePerspectiveMap(RootModel[dict[str, IqModePerspective]]):
+    root: dict[str, IqModePerspective]
 
 
 class ListOrgCustomRolesResponseContent(BaseModel):

--- a/python/api_model/types/models.py
+++ b/python/api_model/types/models.py
@@ -606,7 +606,10 @@ class EqDurationCard(BaseModel):
 
 
 class EqModeCardFlag(BaseModel):
+    reasoning: str
+    referenceKey: str
     severity: FlagSeverity
+    summary: str
     context: str
 
 

--- a/python/api_model/types/models.py
+++ b/python/api_model/types/models.py
@@ -181,10 +181,10 @@ class FixedValueTermInference(BaseModel):
 
 
 class FlagSeverity(Enum):
-    red = 'red'
-    yellow = 'yellow'
-    orange = 'orange'
-    blue = 'blue'
+    critical = 'critical'
+    warn = 'warn'
+    info = 'info'
+    positive = 'positive'
 
 
 class GetContractReadURLRequestContent(BaseModel):
@@ -608,7 +608,10 @@ class EqDurationCard(BaseModel):
 class EqModeCardFlag(BaseModel):
     severity: FlagSeverity
     context: str
-    referenceKey: str
+
+
+class EqModeCardFlagMap(RootModel[dict[str, EqModeCardFlag]]):
+    root: dict[str, EqModeCardFlag]
 
 
 class EqOwnershipCard(BaseModel):
@@ -871,7 +874,7 @@ class EqModeCard(BaseModel):
         None,
         pattern='^(https?:\\/\\/)?(www\\.)?[-a-zA-Z0-9@%._\\+~#=]{2,256}\\.[a-z]{2,6}\\b([-a-zA-Z0-9@:%_\\+.~#?&/=]*)$',
     )
-    flags: list[EqModeCardFlag] | None
+    flags: EqModeCardFlagMap | None
 
 
 class EqModeCardMap(RootModel[dict[str, EqModeCard]]):

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -334,7 +334,10 @@ export type EqModeCard = {
 };
 
 export type EqModeCardFlag = {
+  reasoning: string;
+  referenceKey: string;
   severity: FlagSeverity;
+  summary: string;
   context: string;
 };
 

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -66,6 +66,13 @@ export enum EqCardType {
   B = "B"
 }
 
+export enum FlagSeverity {
+  red = "red",
+  yellow = "yellow",
+  orange = "orange",
+  blue = "blue"
+}
+
 export enum InviteStatus {
   pending = "pending",
   accepted = "accepted",
@@ -323,6 +330,13 @@ export type EqModeCard = {
   items?: EqModeItem[];
   audioSrc?: string;
   ttsSrcUrl?: string;
+  flags?: EqModeCardFlag[];
+};
+
+export type EqModeCardFlag = {
+  severity: FlagSeverity;
+  context: string;
+  referenceKey: string;
 };
 
 export type EqModeCardMap = { [key: string]: EqModeCard };

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -67,10 +67,10 @@ export enum EqCardType {
 }
 
 export enum FlagSeverity {
-  red = "red",
-  yellow = "yellow",
-  orange = "orange",
-  blue = "blue"
+  critical = "critical",
+  warn = "warn",
+  info = "info",
+  positive = "positive"
 }
 
 export enum InviteStatus {
@@ -330,14 +330,15 @@ export type EqModeCard = {
   items?: EqModeItem[];
   audioSrc?: string;
   ttsSrcUrl?: string;
-  flags?: EqModeCardFlag[];
+  flags?: EqModeCardFlagMap;
 };
 
 export type EqModeCardFlag = {
   severity: FlagSeverity;
   context: string;
-  referenceKey: string;
 };
+
+export type EqModeCardFlagMap = { [key: string]: EqModeCardFlag };
 
 export type EqModeCardMap = { [key: string]: EqModeCard };
 

--- a/typescript/src/models.ts
+++ b/typescript/src/models.ts
@@ -818,12 +818,14 @@ export interface components {
             /** @description Deprecated, use the ttsSrcUrl */
             audioSrc?: string;
             ttsSrcUrl?: string;
-            flags?: components["schemas"]["EqModeCardFlag"][];
+            flags?: components["schemas"]["EqModeCardFlagMap"];
         };
         EqModeCardFlag: {
             severity: components["schemas"]["FlagSeverity"];
             context: string;
-            referenceKey: string;
+        };
+        EqModeCardFlagMap: {
+            [key: string]: components["schemas"]["EqModeCardFlag"];
         };
         EqModeCardMap: {
             [key: string]: components["schemas"]["EqModeCard"];
@@ -2828,10 +2830,10 @@ export enum EqCardType {
     B = "B"
 }
 export enum FlagSeverity {
-    red = "red",
-    yellow = "yellow",
-    orange = "orange",
-    blue = "blue"
+    critical = "critical",
+    warn = "warn",
+    info = "info",
+    positive = "positive"
 }
 export enum InviteStatus {
     pending = "pending",

--- a/typescript/src/models.ts
+++ b/typescript/src/models.ts
@@ -818,6 +818,12 @@ export interface components {
             /** @description Deprecated, use the ttsSrcUrl */
             audioSrc?: string;
             ttsSrcUrl?: string;
+            flags?: components["schemas"]["EqModeCardFlag"][];
+        };
+        EqModeCardFlag: {
+            severity: components["schemas"]["FlagSeverity"];
+            context: string;
+            referenceKey: string;
         };
         EqModeCardMap: {
             [key: string]: components["schemas"]["EqModeCard"];
@@ -869,6 +875,8 @@ export interface components {
             primary: components["schemas"]["FixedTermValue"];
             subterms?: components["schemas"]["FixedTermValue"][];
         };
+        /** @enum {string} */
+        FlagSeverity: FlagSeverity;
         GetContractReadURLRequestContent: {
             contractId: string;
         };
@@ -2818,6 +2826,12 @@ export enum EqCardKey {
 export enum EqCardType {
     A = "A",
     B = "B"
+}
+export enum FlagSeverity {
+    red = "red",
+    yellow = "yellow",
+    orange = "orange",
+    blue = "blue"
 }
 export enum InviteStatus {
     pending = "pending",

--- a/typescript/src/models.ts
+++ b/typescript/src/models.ts
@@ -821,7 +821,10 @@ export interface components {
             flags?: components["schemas"]["EqModeCardFlagMap"];
         };
         EqModeCardFlag: {
+            reasoning: string;
+            referenceKey: string;
             severity: components["schemas"]["FlagSeverity"];
+            summary: string;
             context: string;
         };
         EqModeCardFlagMap: {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Card-level flags added to EQ Mode Cards, shown optionally per card.
  * Flags include severity levels (Critical, Warn, Info, Positive), a short summary, detailed reasoning, contextual info, and a reference key for each flag.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->